### PR TITLE
Add support for filtering server via labels

### DIFF
--- a/newrelic_api/servers.py
+++ b/newrelic_api/servers.py
@@ -7,7 +7,7 @@ class Servers(Resource):
     """
     An interface for interacting with the NewRelic server API.
     """
-    def list(self, filter_name=None, filter_ids=None, page=None):
+    def list(self, filter_name=None, filter_ids=None, filter_labels=None, page=None):
         """
         This API endpoint returns a paginated list of the Servers
         associated with your New Relic account. Servers can be filtered
@@ -18,6 +18,9 @@ class Servers(Resource):
 
         :type filter_ids: list of ints
         :param filter_ids: Filter by server ids
+
+        :type filter_labels: list of strs
+        :param filter_labels: Filter by server labels
 
         :type page: int
         :param page: Pagination index
@@ -54,6 +57,7 @@ class Servers(Resource):
         filters = [
             'filter[name]={0}'.format(filter_name) if filter_name else None,
             'filter[ids]={0}'.format(','.join([str(app_id) for app_id in filter_ids])) if filter_ids else None,
+            'filter[labels]={0}'.format(';'.join([str(label) for label in filter_labels])) if filter_labels else None,
             'page={0}'.format(page) if page else None
         ]
 

--- a/newrelic_api/servers.py
+++ b/newrelic_api/servers.py
@@ -54,10 +54,11 @@ class Servers(Resource):
             }
 
         """
+        label_param = ';'.join(['{}:{}'.format(label, value) for label, value in filter_labels.items()])
         filters = [
             'filter[name]={0}'.format(filter_name) if filter_name else None,
             'filter[ids]={0}'.format(','.join([str(app_id) for app_id in filter_ids])) if filter_ids else None,
-            'filter[labels]={0}'.format(';'.join(['{}:{}'.format(label, value) for label, value in filter_labels.items()])) if filter_labels else None,
+            'filter[labels]={0}'.format(label_param) if filter_labels else None,
             'page={0}'.format(page) if page else None
         ]
 

--- a/newrelic_api/servers.py
+++ b/newrelic_api/servers.py
@@ -54,7 +54,9 @@ class Servers(Resource):
             }
 
         """
-        label_param = ';'.join(['{}:{}'.format(label, value) for label, value in filter_labels.items()])
+        if filter_labels:
+            label_param = ';'.join(['{}:{}'.format(label, value) for label, value in filter_labels.items()])
+
         filters = [
             'filter[name]={0}'.format(filter_name) if filter_name else None,
             'filter[ids]={0}'.format(','.join([str(app_id) for app_id in filter_ids])) if filter_ids else None,

--- a/newrelic_api/servers.py
+++ b/newrelic_api/servers.py
@@ -19,7 +19,7 @@ class Servers(Resource):
         :type filter_ids: list of ints
         :param filter_ids: Filter by server ids
 
-        :type filter_labels: list of strs
+        :type filter_labels: dict of label type: value pairs
         :param filter_labels: Filter by server labels
 
         :type page: int
@@ -57,7 +57,7 @@ class Servers(Resource):
         filters = [
             'filter[name]={0}'.format(filter_name) if filter_name else None,
             'filter[ids]={0}'.format(','.join([str(app_id) for app_id in filter_ids])) if filter_ids else None,
-            'filter[labels]={0}'.format(';'.join([str(label) for label in filter_labels])) if filter_labels else None,
+            'filter[labels]={0}'.format(';'.join(['{}:{}'.format(label, value) for label, value in filter_labels.items()])) if filter_labels else None,
             'page={0}'.format(page) if page else None
         ]
 

--- a/newrelic_api/tests/servers_tests.py
+++ b/newrelic_api/tests/servers_tests.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from unittest import TestCase
 
 from mock import patch, Mock
@@ -144,7 +145,9 @@ class NRServersTests(TestCase):
         mock_get.return_value = mock_response
 
         # Call the method
-        response = self.server.list(filter_labels={'Type1': 'Value1', 'Type2': 'Value2'})
+        # Use ordered dict to guarantee ordering of labels in query param
+        labels = OrderedDict((('Type1', 'Value1'), ('Type2', 'Value2')))
+        response = self.server.list(filter_labels=labels)
 
         self.assertIsInstance(response, dict)
         mock_get.assert_called_once_with(

--- a/newrelic_api/tests/servers_tests.py
+++ b/newrelic_api/tests/servers_tests.py
@@ -135,6 +135,25 @@ class NRServersTests(TestCase):
         )
 
     @patch.object(requests, 'get')
+    def test_list_success_with_filter_labels(self, mock_get):
+        """
+        Test servers .list() with filter_labels
+        """
+        mock_response = Mock(name='response')
+        mock_response.json.return_value = self.list_success_response
+        mock_get.return_value = mock_response
+
+        # Call the method
+        response = self.server.list(filter_labels=['Type1:Value1', 'Type2:Value2'])
+
+        self.assertIsInstance(response, dict)
+        mock_get.assert_called_once_with(
+            url='https://api.newrelic.com/v2/servers.json',
+            headers=self.server.headers,
+            params='filter[labels]=Type1:Value1;Type2:Value2'
+        )
+
+    @patch.object(requests, 'get')
     def test_list_failure(self, mock_get):
         """
         Test servers .list() failure case

--- a/newrelic_api/tests/servers_tests.py
+++ b/newrelic_api/tests/servers_tests.py
@@ -144,7 +144,7 @@ class NRServersTests(TestCase):
         mock_get.return_value = mock_response
 
         # Call the method
-        response = self.server.list(filter_labels=['Type1:Value1', 'Type2:Value2'])
+        response = self.server.list(filter_labels={'Type1': 'Value1', 'Type2': 'Value2'})
 
         self.assertIsInstance(response, dict)
         mock_get.assert_called_once_with(


### PR DESCRIPTION
This pull request adds support for filtering servers by their labels, as per https://rpm.newrelic.com/api/explore/servers/list