### PR TITLE
Newrelic api change

### DIFF
--- a/newrelic_api/__init__.py
+++ b/newrelic_api/__init__.py
@@ -2,6 +2,7 @@
 from .version import __version__
 
 from .alert_policies import AlertPolicies
+from .alert_conditions import AlertConditions
 from .applications import Applications
 from .application_hosts import ApplicationHosts
 from .application_instances import ApplicationInstances

--- a/newrelic_api/alert_conditions.py
+++ b/newrelic_api/alert_conditions.py
@@ -1,4 +1,5 @@
 from .base import Resource
+from newrelic_api.exceptions import NoEntityException
 
 
 class AlertConditions(Resource):
@@ -68,3 +69,98 @@ class AlertConditions(Resource):
             headers=self.headers,
             params=self.build_param_string(filters)
         )
+
+    def update(
+            self, policy_id, alert_condition_id,
+            condition_type=None,
+            name=None,
+            enabled=None,
+            entities=None,
+            metric=None,
+            terms=None):
+        """
+        Updates any of the optional parameters of the alert condition
+
+        :type policy_id: int
+        :param policy_id: Alert policy id where target alert condition belongs to
+
+        :type alert_condition_id: int
+        :param alert_condition_id: Alerts condition id to update
+
+        :type name: str
+        :param name: The name of the server
+
+        :type enabled: bool
+        :param enabled: Whether to enable that alert condition
+
+        :type entities: list[str]
+        :param name: entity ids to which the alert condition is applied
+
+        :rtype: dict
+        :return: The JSON response of the API
+
+        :raises: This will raise a
+            :class:`NewRelicAPIServerException<newrelic_api.exceptions.NoEntityException>`
+            if target alert condition is not included in target policy
+
+        ::
+
+            {
+                "condition": {
+                    "id": "integer",
+                    "condition_type": "string",
+                    "name": "string",
+                    "enabled": "boolean",
+                    "entities": [
+                        "integer"
+                    ],
+                    "metric": "string",
+                    "runbook_url": "string",
+                    "terms": [
+                        {
+                            "duration": "string",
+                            "operator": "string",
+                            "priority": "string",
+                            "threshold": "string",
+                            "time_function": "string"
+                        }
+                    ],
+                    "user_defined": {
+                        "metric": "string",
+                        "value_function": "string"
+                    }
+                }
+            }
+
+        """
+        conditions_dict = self.list(policy_id)
+        target_condition = None
+        for condition in conditions_dict['conditions']:
+            if int(condition['id']) == alert_condition_id:
+                target_condition = condition
+                break
+
+        if target_condition is None:
+            raise NoEntityException(
+                'Target alert condition is not included in that policy.'
+                'policy_id: {}, alert_condition_id {}'.format(policy_id, alert_condition_id))
+
+        data = {
+            'condition': {
+                'condition_type': condition_type or target_condition['condition_type'],
+                'name': name or target_condition['name'],
+                'enabled': enabled or target_condition['enabled'],
+                'entities': entities or target_condition['entities'],
+                'metric': metric or target_condition['metric'],
+                'terms': terms or target_condition['terms'],
+            }
+        }
+
+        return self._put(
+            url='{0}alerts_conditions/{1}.json'.format(self.URL, alert_condition_id),
+            headers=self.headers,
+            data=data
+        )
+
+    # TODO: implement create and delete
+    # See https://docs.newrelic.com/docs/alerts/new-relic-alerts-beta/getting-started/rest-api-calls-new-relic-alerts

--- a/newrelic_api/alert_conditions.py
+++ b/newrelic_api/alert_conditions.py
@@ -1,0 +1,70 @@
+from .base import Resource
+
+
+class AlertConditions(Resource):
+    """
+    An interface for interacting with the NewRelic Alert Conditions API.
+    """
+    def list(self, policy_id, page=None):
+        """
+        This API endpoint returns a paginated list of alert conditions associated with the
+        given policy_id.
+
+        This API endpoint returns a paginated list of the alert conditions
+        associated with your New Relic account. Alert conditions can be filtered
+        by their name, list of IDs, type (application, key_transaction, or
+        server) or whether or not policies are archived (defaults to filtering
+        archived policies).
+
+        :type policy_id: int
+        :param policy_id: Alert policy id
+
+        :type page: int
+        :param page: Pagination index
+
+        :rtype: dict
+        :return: The JSON response of the API, with an additional 'pages' key
+            if there are paginated results
+
+        ::
+
+            {
+                "conditions": [
+                    {
+                        "id": "integer",
+                        "condition_type": "string",
+                        "name": "string",
+                        "enabled": "boolean",
+                        "entities": [
+                          "integer"
+                        ],
+                        "metric": "string",
+                        "runbook_url": "string",
+                        "terms": [
+                          {
+                            "duration": "string",
+                            "operator": "string",
+                            "priority": "string",
+                            "threshold": "string",
+                            "time_function": "string"
+                          }
+                        ],
+                        "user_defined": {
+                          "metric": "string",
+                          "value_function": "string"
+                        }
+                    }
+                ]
+            }
+
+        """
+        filters = [
+            'policy_id={0}'.format(policy_id),
+            'page={0}'.format(page) if page else None
+        ]
+
+        return self._get(
+            url='{0}alerts_conditions.json'.format(self.URL),
+            headers=self.headers,
+            params=self.build_param_string(filters)
+        )

--- a/newrelic_api/alert_policies.py
+++ b/newrelic_api/alert_policies.py
@@ -5,27 +5,14 @@ class AlertPolicies(Resource):
     """
     An interface for interacting with the NewRelic Alert Policies API.
     """
-    def list(
-            self, filter_name=None, filter_type=None, filter_ids=None,
-            filter_enabled=None, page=None):
+    def list(self, filter_name=None, page=None):
         """
         This API endpoint returns a paginated list of the alert policies
         associated with your New Relic account. Alert policies can be filtered
-        by their name, list of IDs, type (application, key_transaction, or
-        server) or whether or not policies are archived (defaults to filtering
-        archived policies).
+        by their name with exact match.
 
         :type filter_name: str
         :param filter_name: Filter by name
-
-        :type filter_type: list of str
-        :param filter_type: Filter by policy types.
-
-        :type filter_ids: list of int
-        :param filter_ids: Filter by policy IDs
-
-        :type filter_enabled: bool
-        :param filter_enabled: Select only enabled/disabled policies (default: both)
 
         :type page: int
         :param page: Pagination index
@@ -37,204 +24,27 @@ class AlertPolicies(Resource):
         ::
 
             {
-                "alert_policies": [
+                "policies": [
                     {
                         "id": "integer",
-                        "type": "string",
+                        "rollup_strategy": "string",
                         "name": "string",
-                        "enabled": "boolean",
-                        "conditions": [
-                            {
-                                "id": "integer",
-                                "type": "string",
-                                "severity": "string",
-                                "threshold": "float",
-                                "trigger_minutes": "integer",
-                                "enabled": "boolean"
-                            }
-                        ],
-                        "links": {
-                            "notification_channels": [
-                                "integer"
-                            ],
-                            "applications": [
-                                "integer"
-                            ],
-                            "key_transactions": [
-                                "integer"
-                            ],
-                            "servers": [
-                                "integer"
-                            ]
-                        }
-                    }
-                ],
-                "pages": {
-                    "last": {
-                        "url": "https://api.newrelic.com/v2/alert_policies.json?page=2",
-                        "rel": "last"
+                        "created_at": "integer",
                     },
-                    "next": {
-                        "url": "https://api.newrelic.com/v2/alert_policies.json?page=2",
-                        "rel": "next"
-                    }
-                }
+                ]
             }
 
         """
         filters = [
             'filter[name]={0}'.format(filter_name) if filter_name else None,
-            'filter[type]={0}'.format(','.join(filter_type)) if filter_type else None,
-            'filter[ids]={0}'.format(','.join([str(app_id) for app_id in filter_ids])) if filter_ids else None,
-            'filter[enabled]={0}'.format(filter_enabled) if filter_enabled in [True, False] else None,
             'page={0}'.format(page) if page else None
         ]
 
         return self._get(
-            url='{0}alert_policies.json'.format(self.URL),
+            url='{0}alerts_policies.json'.format(self.URL),
             headers=self.headers,
             params=self.build_param_string(filters)
         )
 
-    def show(self, id):
-        """
-        This API endpoint returns a single alert policy, identified by ID.
-
-        :type id: int
-        :param id: Alert policy ID
-
-        :rtype: dict
-        :return: The JSON response of the API
-
-        ::
-
-            {
-                "alert_policy": {
-                    "id": "integer",
-                    "type": "string",
-                    "name": "string",
-                    "enabled": "boolean",
-                    "conditions": [
-                        {
-                            "id": "integer",
-                            "type": "string",
-                            "severity": "string",
-                            "threshold": "float",
-                            "trigger_minutes": "integer",
-                            "enabled": "boolean"
-                        }
-                    ],
-                    "links": {
-                        "notification_channels": [
-                            "integer"
-                        ],
-                        "applications": [
-                            "integer"
-                        ],
-                        "key_transactions": [
-                            "integer"
-                        ],
-                        "servers": [
-                            "integer"
-                        ]
-                    }
-                }
-            }
-
-        """
-        return self._get(
-            url='{0}alert_policies/{1}.json'.format(self.URL, id),
-            headers=self.headers,
-        )
-
-    def update(self, id, policy_update):
-        """
-        This API endpoint allows you to update your alert policies.
-
-        The input is expected to be in **JSON** format in the body
-        parameters of the PUT request. The exact schema is defined below. Any
-        extra parameters passed in the body **will be ignored** .::
-
-            {
-                "alert_policy": {
-                    "name": str,
-                    "enabled": bool,
-                    "conditions": [
-                        {
-                            "id": int,
-                            "threshold": float,
-                            "trigger_minutes": int,
-                            "enabled": bool
-                        }
-                    ],
-                    "links": {
-                        "notification_channels": [
-                            int
-                        ],
-                        "applications": [
-                            int
-                        ],
-                        "key_transactions": [
-                            "int
-                        ],
-                        "servers": [
-                            int
-                        ]
-                    }
-                }
-            }
-
-        **NOTE:** When updating alertable and notification channel links, the
-        list sent replaces the existing list. Invalid values will be ignored
-        but an empty array will result in alertables/channels being reset.
-
-        :type id: int
-        :param id: Alert policy ID
-
-        :type policy_update: dict
-        :param policy_update: The json of the policy to update
-
-        :rtype: dict
-        :return: The JSON response of the API
-
-        ::
-
-            {
-                "alert_policy": {
-                    "id": "integer",
-                    "type": "string",
-                    "name": "string",
-                    "enabled": "boolean",
-                    "conditions": [
-                        {
-                            "id": "integer",
-                            "type": "string",
-                            "severity": "string",
-                            "threshold": "float",
-                            "trigger_minutes": "integer",
-                            "enabled": "boolean"
-                        }
-                    ],
-                    "links": {
-                        "notification_channels": [
-                            "integer"
-                        ],
-                        "applications": [
-                            "integer"
-                        ],
-                        "key_transactions": [
-                            "integer"
-                        ],
-                        "servers": [
-                            "integer"
-                        ]
-                    }
-                }
-            }
-
-        """
-        return self._put(
-            url='{0}alert_policies/{1}.json'.format(self.URL, id),
-            headers=self.headers,
-            data=policy_update
-        )
+    # TODO: implement create and delete
+    # See https://docs.newrelic.com/docs/alerts/new-relic-alerts-beta/getting-started/rest-api-calls-new-relic-alerts

--- a/newrelic_api/base.py
+++ b/newrelic_api/base.py
@@ -28,7 +28,7 @@ class Resource(object):
 
         self.headers = {
             'Content-type': 'application/json',
-            'X-Api-Key': self.api_key,
+            'NewRelic-Api-Key': self.api_key,
         }
 
     def _get(self, *args, **kwargs):

--- a/newrelic_api/exceptions.py
+++ b/newrelic_api/exceptions.py
@@ -10,3 +10,10 @@ class NewRelicAPIServerException(Exception):
     An exception for New Relic server errors
     """
     message = 'There was an error from New Relic'
+
+
+class NoEntityException(Exception):
+    """
+    An exception for operation to no existed entities
+    """
+    message = 'No entity exists'

--- a/newrelic_api/tests/alert_conditions_tests.py
+++ b/newrelic_api/tests/alert_conditions_tests.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from mock import patch, Mock
+import requests
+
+from newrelic_api.alert_conditions import AlertConditions
+
+
+class NRAlertConditionsTests(TestCase):
+    def setUp(self):
+        super(NRAlertConditionsTests, self).setUp()
+        self.conditions = AlertConditions(api_key='dummy_key')
+
+        self.conditions_list_response = {
+            "conditions": [
+                {
+                    "id": "1",
+                    "condition_type": "servers_metric",
+                    "name": "CPU usage alert",
+                    "enabled": True,
+                    "entities": [
+                        "1234567"
+                    ],
+                    "metric": "cpu_percentage",
+                    "terms": [
+                        {
+                            "duration": "5",
+                            "operator": "above",
+                            "priority": "above",
+                            "threshold": "90",
+                            "time_function": "all"
+                        }
+                    ]
+                }
+            ]
+        }
+
+    @patch.object(requests, 'get')
+    def test_list_success(self, mock_get):
+        """
+        Test alert conditions .list()
+        """
+        mock_response = Mock(name='response')
+        mock_response.json.return_value = self.conditions_list_response
+        mock_get.return_value = mock_response
+
+        # Call the method
+        response = self.conditions.list(policy_id=1)
+
+        self.assertIsInstance(response, dict)
+
+    @patch.object(requests, 'get')
+    def test_list_failure(self, mock_get):
+        """
+        Test alert conditions .list() failure case
+        """
+        mock_response = Mock(name='response')
+        mock_response.json.side_effect = ValueError('No JSON object could be decoded')
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            # Call the method
+            self.conditions.list(policy_id=1)

--- a/newrelic_api/tests/alert_conditions_tests.py
+++ b/newrelic_api/tests/alert_conditions_tests.py
@@ -4,17 +4,18 @@ from mock import patch, Mock
 import requests
 
 from newrelic_api.alert_conditions import AlertConditions
+from newrelic_api.exceptions import NoEntityException
 
 
 class NRAlertConditionsTests(TestCase):
     def setUp(self):
         super(NRAlertConditionsTests, self).setUp()
-        self.conditions = AlertConditions(api_key='dummy_key')
+        self.alert_conditions = AlertConditions(api_key='dummy_key')
 
-        self.conditions_list_response = {
+        self.list_success_response = {
             "conditions": [
                 {
-                    "id": "1",
+                    "id": "100",
                     "condition_type": "servers_metric",
                     "name": "CPU usage alert",
                     "enabled": True,
@@ -35,17 +36,39 @@ class NRAlertConditionsTests(TestCase):
             ]
         }
 
+        self.update_success_response = {
+            "condition": {
+                "id": "100",
+                "condition_type": "servers_metric",
+                "name": "CPU usage alert",
+                "enabled": True,
+                "entities": [
+                    "1234567"
+                ],
+                "metric": "cpu_percentage",
+                "terms": [
+                    {
+                        "duration": "5",
+                        "operator": "above",
+                        "priority": "above",
+                        "threshold": "90",
+                        "time_function": "all"
+                    }
+                ]
+            }
+        }
+
     @patch.object(requests, 'get')
     def test_list_success(self, mock_get):
         """
         Test alert conditions .list()
         """
         mock_response = Mock(name='response')
-        mock_response.json.return_value = self.conditions_list_response
+        mock_response.json.return_value = self.list_success_response
         mock_get.return_value = mock_response
 
         # Call the method
-        response = self.conditions.list(policy_id=1)
+        response = self.alert_conditions.list(policy_id=1)
 
         self.assertIsInstance(response, dict)
 
@@ -60,4 +83,56 @@ class NRAlertConditionsTests(TestCase):
 
         with self.assertRaises(ValueError):
             # Call the method
-            self.conditions.list(policy_id=1)
+            self.alert_conditions.list(policy_id=1)
+
+    @patch.object(requests, 'get')
+    @patch.object(requests, 'put')
+    def test_update_success(self, mock_put, mock_get):
+        """
+        Test alerts_conditions .update() success
+        """
+        mock_list_response = Mock(name='response')
+        mock_list_response.json.return_value = self.list_success_response
+        mock_update_response = Mock(name='response')
+        mock_update_response.json.return_value = self.update_success_response
+        mock_get.return_value = mock_list_response
+        mock_put.return_value = mock_update_response
+
+        # Call the method
+        response = self.alert_conditions.update(policy_id=1, alert_condition_id=100, name='New Name')
+
+        self.assertIsInstance(response, dict)
+
+    @patch.object(requests, 'get')
+    @patch.object(requests, 'put')
+    def test_update_failure(self, mock_put, mock_get):
+        """
+        Test alerts_conditions .update() failure
+        """
+        mock_list_response = Mock(name='response')
+        mock_list_response.json.return_value = self.list_success_response
+        mock_update_response = Mock(name='response')
+        mock_update_response.json.side_effect = ValueError('No JSON object could be decoded')
+        mock_get.return_value = mock_list_response
+        mock_put.return_value = mock_update_response
+
+        # Call the method
+        with self.assertRaises(ValueError):
+            self.alert_conditions.update(policy_id=1, alert_condition_id=100, name='New Name')
+
+    @patch.object(requests, 'get')
+    @patch.object(requests, 'put')
+    def test_update_no_alert_condition(self, mock_put, mock_get):
+        """
+        Test alerts_conditions .update() success
+        """
+        mock_list_response = Mock(name='response')
+        mock_list_response.json.return_value = self.list_success_response
+        mock_update_response = Mock(name='response')
+        mock_update_response.json.return_value = self.update_success_response
+        mock_get.return_value = mock_list_response
+        mock_put.return_value = mock_update_response
+
+        with self.assertRaises(NoEntityException):
+            # Call the method with non existing alert_condition_id
+            self.alert_conditions.update(policy_id=1, alert_condition_id=9999, name='New Name')

--- a/newrelic_api/tests/alert_policies_tests.py
+++ b/newrelic_api/tests/alert_policies_tests.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase
 
 from mock import patch, Mock
@@ -13,103 +12,14 @@ class NRAlertPoliciesTests(TestCase):
         self.policies = AlertPolicies(api_key='dummy_key')
 
         self.policies_list_response = {
-            "alert_policies": [
+            "policies": [
                 {
                     "id": 12345,
-                    "type": "server",
+                    "rollup_strategy": "PER_CONDITION_AND_TARGET",
                     "name": "Default Server Policy",
-                    "enabled": True,
-                    "conditions": [
-                        {
-                            "id": 347535,
-                            "type": "disk_io",
-                            "severity": "caution",
-                            "threshold": 70,
-                            "trigger_minutes": 20,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347536,
-                            "type": "disk_io",
-                            "severity": "critical",
-                            "threshold": 90,
-                            "trigger_minutes": 15,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347537,
-                            "type": "fullest_disk",
-                            "severity": "caution",
-                            "threshold": 70,
-                            "trigger_minutes": 10,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347538,
-                            "type": "fullest_disk",
-                            "severity": "critical",
-                            "threshold": 90,
-                            "trigger_minutes": 5,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347539,
-                            "type": "memory",
-                            "severity": "caution",
-                            "threshold": 80,
-                            "trigger_minutes": 10,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347540,
-                            "type": "memory",
-                            "severity": "critical",
-                            "threshold": 95,
-                            "trigger_minutes": 5,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347541,
-                            "type": "cpu",
-                            "severity": "caution",
-                            "threshold": 60,
-                            "trigger_minutes": 20,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347542,
-                            "type": "cpu",
-                            "severity": "critical",
-                            "threshold": 90,
-                            "trigger_minutes": 15,
-                            "enabled": True
-                        },
-                        {
-                            "id": 347543,
-                            "type": "server_downtime",
-                            "severity": "downtime",
-                            "trigger_minutes": 5,
-                            "enabled": True
-                        }
-                    ],
-                    "links": {
-                        "notification_channels": [
-                            333444
-                        ],
-                        "servers": [
-                            1234567,
-                            2345678,
-                            3456789,
-                            4567890,
-                            5678901,
-                            6789012
-                        ]
-                    }
+                    "created_at": 123456789012,
                 }
             ]
-        }
-        self.policy_show_response = {
-            'alert_policy': self.policies_list_response['alert_policies'][0]
         }
 
     @patch.object(requests, 'get')
@@ -127,7 +37,7 @@ class NRAlertPoliciesTests(TestCase):
         self.assertIsInstance(response, dict)
 
     @patch.object(requests, 'get')
-    def test_list_success_with_ids(self, mock_get):
+    def test_list_success_with_name(self, mock_get):
         """
         Test alert policies .list() with filter_ids
         """
@@ -136,13 +46,13 @@ class NRAlertPoliciesTests(TestCase):
         mock_get.return_value = mock_response
 
         # Call the method
-        response = self.policies.list(filter_ids=[12345])
+        response = self.policies.list(filter_name='Default Server Policy')
 
         self.assertIsInstance(response, dict)
         mock_get.assert_called_once_with(
-            url='https://api.newrelic.com/v2/alert_policies.json',
+            url='https://api.newrelic.com/v2/alerts_policies.json',
             headers=self.policies.headers,
-            params='filter[ids]=12345'
+            params='filter[name]=Default Server Policy'
         )
 
     @patch.object(requests, 'get')
@@ -157,43 +67,3 @@ class NRAlertPoliciesTests(TestCase):
         with self.assertRaises(ValueError):
             # Call the method
             self.policies.list()
-
-    @patch.object(requests, 'get')
-    def test_show_success(self, mock_get):
-        """
-        Test alert policies .show() success
-        """
-        mock_response = Mock(name='response')
-        mock_response.json.return_value = self.policy_show_response
-        mock_get.return_value = mock_response
-
-        # Call the method
-        response = self.policies.show(id=333112)
-
-        self.assertIsInstance(response, dict)
-
-    @patch.object(requests, 'get')
-    def test_show_failure(self, mock_get):
-        """
-        Test alert policies .show() failure
-        """
-        mock_response = Mock(name='response')
-        mock_response.json.side_effect = ValueError('No JSON object could be decoded')
-        mock_get.return_value = mock_response
-
-        with self.assertRaises(ValueError):
-            # Call the method
-            self.policies.show(id=333114)
-
-    @patch.object(requests, 'put')
-    def test_update(self, mock_put):
-        """
-        Test alert policies .update() calls put with correct parameters
-        """
-        self.policies.update(id=333114, policy_update=self.policy_show_response)
-
-        mock_put.assert_called_once_with(
-            url='https://api.newrelic.com/v2/alert_policies/333114.json',
-            headers=self.policies.headers,
-            data=json.dumps(self.policy_show_response)
-        )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# import multiprocessing to avoid this bug (http://bugs.python.org/issue15881#msg170215)
-import multiprocessing
-assert multiprocessing
 import re
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Now that newrelic has renewed their rest APIs, 
https://blog.newrelic.com/2015/11/12/announcement-api-additions/
I added some changes to this client.
- update `alert_policies` to match the latest spec. old end-points are already deprecated and returning `410 Gone` response.
- add client for `alerts_conditions` end-point.

In both end-points above, create and delete is not implemented yet. And there would exist more end-points to be added or modified. But I think this can be a good start to catch up with the latest newrelic rest APIs.
